### PR TITLE
Build: Initialize CPP Configuration

### DIFF
--- a/.clang-format.yaml
+++ b/.clang-format.yaml
@@ -1,0 +1,4 @@
+# .clang-format
+---
+# Use the Google style as the foundation for all rules.
+BasedOnStyle: Google

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+# VS Code config
+.vscode
+
+# Competitive Programming Helper Extension (.cph) file
+*.cph
+
+# Code Testing
+*test.py
+*test.cpp
+*.exe

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,12 @@
+{
+    "tabWidth": 4,
+    "useTabs": false,
+    "singleQuote": false,
+    "trailingComma": "none",
+    "bracketSpacing": true,
+    "printWidth": 80,
+    "proseWrap": "always",
+    "arrowParens": "always",
+    "embeddedLanguageFormatting": "auto",
+    "htmlWhitespaceSensitivity": "ignore"
+}


### PR DESCRIPTION
## Description
- Using `clang-formatter` with Google style coding to standardize the C++ code.
- Create `.clang-format.yaml` as the configuration file of `clang-format`.
- Create `.gitignore` to ignore unnecessary files.
- Create `.prettierrc` standardize for markdown files.